### PR TITLE
Add cmake directives for finding Qt

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -39,7 +39,7 @@ In order to build everything, you need to have Qt SDK 4.8 and CMake installed:
   ...> git submodule update
   ...> mkdir build
   ...> cd build
-  .../build> cmake ..
+  .../build> cmake .. -DQT_QMAKE_EXECUTABLE:PATH=/usr/local/Cellar/qt/4.8.6/bin/qmake -DQT_MOC_EXECUTABLE:PATH=/usr/local/Cellar/qt/4.8.6/bin/moc
   .../build> make -j4
   .../build> make install
 


### PR DESCRIPTION
cmake has trouble finding Qt4.8 and reports the following error:
-- Could NOT find Qt4 (missing:  QT_MOC_EXECUTABLE QT_RCC_EXECUTABLE QT_UIC_EXECUTABLE QT_INCLUDE_DIR) (found version "4.7.1")
Workaround specified here:
http://www.cmake.org/pipermail/cmake/2013-May/054847.html
